### PR TITLE
automated the env making process via just one command

### DIFF
--- a/.env_sample
+++ b/.env_sample
@@ -1,0 +1,5 @@
+PORT=5000
+MONGO_URI=<Your MongoDB URI>
+JWT_SECRET=<SecretString you want to have>
+JWT_EXPIRES_IN=7d
+JWT_COOKIE_EXPIRE=7d

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@
     JWT_EXPIRES_IN=7d
     JWT_COOKIE_EXPIRE=7d
     ```
+    OR 
+
+    ```
+    cp .env_sample .env
+    ```
 4. Run ``` yarn start ```
 5. Root directory is used for the backend of the applicaton and the frontend package is contained in  ``` client ``` folder.
 6. Hit Star 😍 if you find this amazing.


### PR DESCRIPTION
Scenario - When any developer, came for the first time, he/she have to create a .env file and then copy-paste the content from the readme. This seems a bit boring :)

I have created a sample env, and via using the command `    cp .env_sample .env     `, the user can simply get the env at its place. Now he/she can just simply reply the fields needed with their tokens and work is done 

